### PR TITLE
Issue 41/404 page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "deploy": "gh-pages -d dist",
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && cp dist/index.html dist/404.html",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Footer from "./components/Footer";
 import Resources from "./components/Resources";
 import ExecutiveForm from "./components/ExecutiveForm";
 import ProjectProposalForm from "./components/ProjectProposalForm";
+import NotFound from "./components/NotFound";
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
               path="/forms/project-proposal"
               element={<ProjectProposalForm />}
             />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
         <Footer />

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const NotFound = () => {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
+    <div className="flex flex-col items-center justify-center min-h-[80vh] text-center px-6">
       <h1 className="text-9xl font-bold logo-gradient mb-8">404</h1>
       <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">Page Not Found</h2>
       <p className="text-xl text-gray-300 max-w-lg mb-10">

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NotFound = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
+      <h1 className="text-9xl font-bold logo-gradient mb-8">404</h1>
+      <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">Page Not Found</h2>
+      <p className="text-xl text-gray-300 max-w-lg mb-10">
+        Oops! The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.
+      </p>
+      <Link to="/" className="btn btn-primary">
+        Go Back Home
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
Fixing #41 

This PR implements a custom 404 page to replace the generic GitHub Pages error screen, ensuring a consistent experience across the website.